### PR TITLE
Add support for overriding installation prefix in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,10 @@ CFLAGS += -Wabi -Wcast-qual -Wfloat-equal -Wmissing-declarations \
 	-Wno-missing-braces -Wno-sign-compare -Wno-multichar -fanalyzer
 endif
 
-BINDIR=/usr/sbin
-MANDIR=/usr/share/man/man8
-BASHDIR=/usr/share/bash-completion/completions
+PREFIX=/usr
+BINDIR=$(PREFIX)/bin
+MANDIR=$(PREFIX)/share/man/man8
+BASHDIR=$(PREFIX)/share/bash-completion/completions
 
 fnotifystat: fnotifystat.o
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)


### PR DESCRIPTION
This simplifies the build process for chromebrew, so we don't have to manually install files to the correct directories. 